### PR TITLE
feat(core:features): add types for `signTransaction` feature

### DIFF
--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -1,10 +1,12 @@
 import type { WalletWithFeatures } from '@wallet-standard/base';
 import type { BitcoinConnectFeature } from './connect.js';
+import type { BitcoinSignTransactionFeature } from './signTransaction.js';
 
 /** Type of all Bitcoin features. */
-export type BitcoinFeatures = BitcoinConnectFeature;
+export type BitcoinFeatures = BitcoinConnectFeature & BitcoinSignTransactionFeature;
 
 /** Wallet with Bitcoin features. */
 export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
 
 export * from './connect.js';
+export * from './signTransaction.js';

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -55,7 +55,7 @@ export interface BitcoinSignTransactionInput {
      */
     readonly inputsToSign: InputToSign[];
     /**
-     * Whether a Wallet should broadcast the signed transaction.
+     * Whether the wallet should broadcast the signed transaction.
      */
     readonly broadcast?: boolean;
 }

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,0 +1,88 @@
+import type { Wallet, WalletAccount } from '@wallet-standard/base';
+import type { Bytes } from './types.js';
+
+/** Name of the feature. */
+export const BitcoinSignTransaction = 'bitcoin:signTransaction';
+
+/**
+ * `bitcoin:signTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
+ * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a transaction with the specified
+ * {@link "@wallet-standard/base".Wallet.accounts | account}.
+ *
+ * @group SignTransaction
+ */
+export type BitcoinSignTransactionFeature = {
+    /** Name of the feature. */
+    readonly [BitcoinSignTransaction]: {
+        /** Version of the feature implemented by the Wallet. */
+        readonly version: BitcoinSignTransactionVersion;
+        /** Method to call to use the feature. */
+        readonly signTransaction: BitcoinSignTransactionMethod;
+    };
+};
+
+/**
+ * Version of the {@link BitcoinSignTransactionFeature} implemented by a {@link "@wallet-standard/base".Wallet}.
+ *
+ * @group SignTransaction
+ */
+export type BitcoinSignTransactionVersion = '1.0.0';
+
+/**
+ * Method to call to use the {@link BitcoinSignTransactionFeature}.
+ *
+ * @group SignTransaction
+ */
+export type BitcoinSignTransactionMethod = (
+    input: BitcoinSignTransactionInput
+) => Promise<BitcoinSignTransactionOutput>;
+
+/**
+ * Input for the {@link BitcoinSignTransactionMethod}.
+ *
+ * @group SignTransaction
+ */
+export interface BitcoinSignTransactionInput {
+    /**
+     * Partially signed PSBT.
+     */
+    psbt: Bytes;
+    /**
+     * Chain name. Should be one of the {@link "@wallet-standard/base".Wallet.chains}
+     */
+    chain: ArrayElement<Wallet['chains']>;
+    inputsToSign: readonly InputToSign[];
+    broadcast?: boolean;
+}
+
+/** A helper type to infer an array element type. */
+type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
+
+/** Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
+ *
+ * @group SignTransaction
+ * */
+export interface InputToSign {
+    /** Which {@link "@wallet-standard/base".WalletAccount.address } should sign inputs. */
+    address: WalletAccount['address'];
+    /** A list of input indexes that should be signed by the {@link "@wallet-standard/base".WalletAccount.address}. */
+    signingIndexes: number[];
+    /** A SIGHASH flag. */
+    sigHash?: number;
+}
+
+/**
+ * Output of the {@link BitcoinSignTransactionMethod}.
+ *
+ * @group SignTransaction
+ */
+export interface BitcoinSignTransactionOutput {
+    /**
+     * Partially signed PSBT.
+     */
+    psbt: Bytes;
+    /**
+     * Transaction hash. Returned if "broadcast: true" was passed in the {@link BitcoinSignTransactionInput}.
+     */
+    txId?: string;
+}

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,5 +1,4 @@
 import type { Wallet, WalletAccount } from '@wallet-standard/base';
-import type { Bytes } from './types.js';
 
 /** Name of the feature. */
 export const BitcoinSignTransaction = 'bitcoin:signTransaction';
@@ -46,13 +45,19 @@ export interface BitcoinSignTransactionInput {
     /**
      * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
      */
-    psbt: Bytes;
+    readonly psbt: Uint8Array;
     /**
      * Chain to use.
      */
-    chain: ArrayElement<Wallet['chains']>;
-    inputsToSign: readonly InputToSign[];
-    broadcast?: boolean;
+    readonly chain: ArrayElement<Wallet['chains']>;
+    /**
+     * Transaction inputs to sign.
+     */
+    readonly inputsToSign: InputToSign[];
+    /**
+     * Whether a Wallet should broadcast the signed transaction.
+     */
+    readonly broadcast?: boolean;
 }
 
 /** A helper type to infer an array element type. */
@@ -80,7 +85,7 @@ export interface BitcoinSignTransactionOutput {
     /**
      * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
      */
-    psbt: Bytes;
+    readonly psbt: Uint8Array;
     /**
      * Transaction hash.
      * Returned if `broadcast: true` was passed in the {@link BitcoinSignTransactionInput}.

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -44,11 +44,11 @@ export type BitcoinSignTransactionMethod = (
  */
 export interface BitcoinSignTransactionInput {
     /**
-     * Partially signed PSBT.
+     * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
      */
     psbt: Bytes;
     /**
-     * Chain name. Should be one of the {@link "@wallet-standard/base".Wallet.chains}
+     * Chain to use.
      */
     chain: ArrayElement<Wallet['chains']>;
     inputsToSign: readonly InputToSign[];
@@ -63,9 +63,9 @@ type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
  * @group SignTransaction
  * */
 export interface InputToSign {
-    /** Which {@link "@wallet-standard/base".WalletAccount.address } should sign inputs. */
+    /** Address to use. */
     address: WalletAccount['address'];
-    /** A list of input indexes that should be signed by the {@link "@wallet-standard/base".WalletAccount.address}. */
+    /** List of input indexes that should be signed by the address. */
     signingIndexes: number[];
     /** A SIGHASH flag. */
     sigHash?: number;
@@ -78,11 +78,12 @@ export interface InputToSign {
  */
 export interface BitcoinSignTransactionOutput {
     /**
-     * Partially signed PSBT.
+     * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
      */
     psbt: Bytes;
     /**
-     * Transaction hash. Returned if "broadcast: true" was passed in the {@link BitcoinSignTransactionInput}.
+     * Transaction hash.
+     * Returned if `broadcast: true` was passed in the {@link BitcoinSignTransactionInput}.
      */
     txId?: string;
 }

--- a/packages/core/features/src/types.ts
+++ b/packages/core/features/src/types.ts
@@ -1,1 +1,0 @@
-export type Bytes = Readonly<Uint8Array>;

--- a/packages/core/features/src/types.ts
+++ b/packages/core/features/src/types.ts
@@ -1,0 +1,1 @@
+export type Bytes = Readonly<Uint8Array>;


### PR DESCRIPTION
Proposes types for the `signTransaction` feature. It's mostly insired by the existing APIs, such as

1. https://docs.xverse.app/sats-connect/
2. https://hirowallet.gitbook.io/developers/bitcoin/sign-transactions/partially-signed-bitcoin-transactions-psbts

and also coupled to the Wallet Standard interfaces. 

### Notes:
It would be great to make it in a pure Wallet Standard manner by getting rid of the `chain` property and supplying an `account: WalletAccount` instance in the `inputsToSign` list. But it's not guaranteed the `chains` list here includes just one element
https://github.com/wallet-standard/wallet-standard/blob/master/packages/core/base/src/wallet.ts#L142 so it would not be clear which chain a wallet should actually use. If we could assume that a wallet provides separate `WalletAccount`'s  instances for each chain, it would allow us to adopt a more idiomatic approach. Wdyt?