### PR TITLE
refactor(examples:dapp): hide wallets not supporting `bitcoin:connect` feature

### DIFF
--- a/packages/examples/dapp/package.json
+++ b/packages/examples/dapp/package.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.4.2"
     },
     "devDependencies": {
+        "@wallet-standard/base": "^1.0.1",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
         "parcel": "^2.8.1",

--- a/packages/examples/dapp/src/pages/Connect.tsx
+++ b/packages/examples/dapp/src/pages/Connect.tsx
@@ -7,6 +7,13 @@ import React, { useEffect } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 
 import { useIsConnected } from '../hooks/useIsConnected';
+import { BitcoinConnect } from '@exodus/bitcoin-wallet-standard-features';
+
+import type { Wallet } from '@wallet-standard/base';
+
+function hasBitcoinConnectFeature(wallet: Wallet): boolean {
+    return BitcoinConnect in wallet.features;
+}
 
 const purposes: BitcoinAddressPurpose[] = ['payment', 'ordinals'];
 
@@ -38,7 +45,7 @@ export const Connect: FC = () => {
         <div className="flex min-h-screen flex-col items-center justify-center">
             <h1 className="mb-4 text-lg font-medium uppercase tracking-wide">Connect Wallet</h1>
             <ul className="mb-8 flex flex-col">
-                {wallets.map((wallet, index) => (
+                {wallets.filter(hasBitcoinConnectFeature).map((wallet, index) => (
                     <li key={wallet.name}>
                         <button
                             className={classNames(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.0.6
         version: 18.2.6
+      '@wallet-standard/base':
+        specifier: ^1.0.1
+        version: 1.0.1
       parcel:
         specifier: ^2.8.1
         version: 2.9.2(postcss@8.4.24)
@@ -1912,7 +1915,6 @@ packages:
   /@wallet-standard/base@1.0.1:
     resolution: {integrity: sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==}
     engines: {node: '>=16'}
-    dev: false
 
   /@wallet-standard/experimental-features@0.1.1:
     resolution: {integrity: sha512-WKtnET1okeDACTbxmePGOGaIUrGvlu/DestLZvZ/ddFpUKw7nokkbinX/gHzsuAC9WGtLyhqLSppAHzN+vAAaQ==}


### PR DESCRIPTION
A small UX improvement to drop non-Bitcoin wallets from the wallets list.

### Tested with Exodus:

## Previously:

<img width="912" alt="image" src="https://github.com/ExodusMovement/bitcoin-wallet-standard/assets/8983736/da52cbbe-6311-429b-9270-af99a07f94da">


## After:

<img width="908" alt="image" src="https://github.com/ExodusMovement/bitcoin-wallet-standard/assets/8983736/99ec99e5-3349-4f51-bc9a-124152c6fd96">

