### PR TITLE
feat(core:features): improve signTransaction types

### DIFF
--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,4 +1,4 @@
-import type { IdentifierString, Wallet, WalletAccount } from '@wallet-standard/base';
+import type { IdentifierString, WalletAccount } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const BitcoinSignTransaction = 'bitcoin:signTransaction';

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletAccount } from '@wallet-standard/base';
+import type { IdentifierString, Wallet, WalletAccount } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const BitcoinSignTransaction = 'bitcoin:signTransaction';
@@ -45,15 +45,12 @@ export interface BitcoinSignTransactionInput {
     /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
     /** Chain to use. */
-    readonly chain: ArrayElement<Wallet['chains']>;
+    readonly chain: IdentifierString;
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
     /** Whether the wallet should broadcast the signed transaction. */
     readonly broadcast?: boolean;
 }
-
-/** A helper type to infer an array element type. */
-type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
 /**
  * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -62,7 +62,7 @@ export interface InputToSign {
     /** Account to use. */
     readonly account: WalletAccount;
 
-    /** List of input indexes that should be signed by the address. */
+    /** List of input indexes that should be signed by the account. */
     readonly signingIndexes: number[];
 
     /** A SIGHASH flag. */

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -57,11 +57,11 @@ export interface BitcoinSignTransactionInput {
  * */
 export interface InputToSign {
     /** Account to use. */
-    account: WalletAccount;
+    readonly account: WalletAccount;
     /** List of input indexes that should be signed by the address. */
-    signingIndexes: number[];
+    readonly signingIndexes: number[];
     /** A SIGHASH flag. */
-    sigHash?: number;
+    readonly sigHash?: number;
 }
 
 /**

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -44,10 +44,10 @@ export type BitcoinSignTransactionMethod = (
 export interface BitcoinSignTransactionInput {
     /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
-    /** Chain to use. */
-    readonly chain: IdentifierString;
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
+    /** Chain to use. */
+    readonly chain?: IdentifierString;
 }
 
 /**

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -5,7 +5,7 @@ export const BitcoinSignTransaction = 'bitcoin:signTransaction';
 
 /**
  * `bitcoin:signTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
- * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a transaction with the specified
+ * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign transactions with the specified
  * {@link "@wallet-standard/base".Wallet.accounts}.
  *
  * @group SignTransaction
@@ -33,8 +33,8 @@ export type BitcoinSignTransactionVersion = '1.0.0';
  * @group SignTransaction
  */
 export type BitcoinSignTransactionMethod = (
-    input: BitcoinSignTransactionInput
-) => Promise<BitcoinSignTransactionOutput>;
+    ...inputs: readonly BitcoinSignTransactionInput[]
+) => Promise<readonly BitcoinSignTransactionOutput[]>;
 
 /**
  * Input for the {@link BitcoinSignTransactionMethod}.

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -15,6 +15,7 @@ export type BitcoinSignTransactionFeature = {
     readonly [BitcoinSignTransaction]: {
         /** Version of the feature implemented by the Wallet. */
         readonly version: BitcoinSignTransactionVersion;
+
         /** Method to call to use the feature. */
         readonly signTransaction: BitcoinSignTransactionMethod;
     };
@@ -44,8 +45,10 @@ export type BitcoinSignTransactionMethod = (
 export interface BitcoinSignTransactionInput {
     /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
+
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
+
     /** Chain to use. */
     readonly chain?: IdentifierString;
 }
@@ -58,8 +61,10 @@ export interface BitcoinSignTransactionInput {
 export interface InputToSign {
     /** Account to use. */
     readonly account: WalletAccount;
+
     /** List of input indexes that should be signed by the address. */
     readonly signingIndexes: number[];
+
     /** A SIGHASH flag. */
     readonly sigHash?: number;
 }

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -6,7 +6,7 @@ export const BitcoinSignTransaction = 'bitcoin:signTransaction';
 /**
  * `bitcoin:signTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
  * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a transaction with the specified
- * {@link "@wallet-standard/base".Wallet.accounts | account}.
+ * {@link "@wallet-standard/base".Wallet.accounts}.
  *
  * @group SignTransaction
  */
@@ -42,28 +42,21 @@ export type BitcoinSignTransactionMethod = (
  * @group SignTransaction
  */
 export interface BitcoinSignTransactionInput {
-    /**
-     * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
-     */
+    /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
-    /**
-     * Chain to use.
-     */
+    /** Chain to use. */
     readonly chain: ArrayElement<Wallet['chains']>;
-    /**
-     * Transaction inputs to sign.
-     */
+    /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
-    /**
-     * Whether the wallet should broadcast the signed transaction.
-     */
+    /** Whether the wallet should broadcast the signed transaction. */
     readonly broadcast?: boolean;
 }
 
 /** A helper type to infer an array element type. */
 type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
-/** Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
+/**
+ * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
  *
  * @group SignTransaction
  * */
@@ -82,12 +75,11 @@ export interface InputToSign {
  * @group SignTransaction
  */
 export interface BitcoinSignTransactionOutput {
-    /**
-     * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
-     */
+    /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
     /**
      * Transaction hash.
+     *
      * Returned if `broadcast: true` was passed in the {@link BitcoinSignTransactionInput}.
      */
     txId?: string;

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -72,8 +72,8 @@ export interface InputToSign {
  * @group SignTransaction
  */
 export interface BitcoinSignTransactionOutput {
-    /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
-    readonly psbt: Uint8Array;
+    /** Signed Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
+    readonly signedPsbt: Uint8Array;
     /**
      * Transaction hash.
      *

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -66,7 +66,7 @@ export interface InputToSign {
     readonly signingIndexes: number[];
 
     /** A SIGHASH flag. */
-    readonly sigHash?: number;
+    readonly sigHash?: BitcoinSigHashFlag;
 }
 
 /**
@@ -78,3 +78,12 @@ export interface BitcoinSignTransactionOutput {
     /** Signed Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly signedPsbt: Uint8Array;
 }
+
+/** SIGHASH flag. */
+export type BitcoinSigHashFlag =
+    | 'ALL'
+    | 'NONE'
+    | 'SINGLE'
+    | 'ALL|ANYONECANPAY'
+    | 'NONE|ANYONECANPAY'
+    | 'SINGLE|ANYONECANPAY';

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -48,8 +48,6 @@ export interface BitcoinSignTransactionInput {
     readonly chain: IdentifierString;
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
-    /** Whether the wallet should broadcast the signed transaction. */
-    readonly broadcast?: boolean;
 }
 
 /**
@@ -74,10 +72,4 @@ export interface InputToSign {
 export interface BitcoinSignTransactionOutput {
     /** Signed Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly signedPsbt: Uint8Array;
-    /**
-     * Transaction hash.
-     *
-     * Returned if `broadcast: true` was passed in the {@link BitcoinSignTransactionInput}.
-     */
-    txId?: string;
 }

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -53,13 +53,13 @@ export interface BitcoinSignTransactionInput {
 }
 
 /**
- * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
+ * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount | account}.
  *
  * @group SignTransaction
  * */
 export interface InputToSign {
-    /** Address to use. */
-    address: WalletAccount['address'];
+    /** Account to use. */
+    account: WalletAccount;
     /** List of input indexes that should be signed by the address. */
     signingIndexes: number[];
     /** A SIGHASH flag. */


### PR DESCRIPTION
## Summary

This PR improves the types of `bitcoin:signTransaction`. Notable changes are:

- Pass entire `WalletAccount` instead of just the address
- Allow to pass multiple inputs
- Make `chain` field optional
- Remove ability to broadcast signed transaction
    - This will be added as a separate `bitcoin:signAndSendTransaction` feature, for consistency with other extensions
- Type `SIGHASH` flags