### PR TITLE
feat(core:features): add signAndSendTransaction feature

### DIFF
--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -1,12 +1,17 @@
 import type { WalletWithFeatures } from '@wallet-standard/base';
 import type { BitcoinConnectFeature } from './connect.js';
+import type { BitcoinSignAndSendTransactionFeature } from './signAndSendTransaction.js';
 import type { BitcoinSignTransactionFeature } from './signTransaction.js';
 
-/** Type of all Bitcoin features. */
-export type BitcoinFeatures = BitcoinConnectFeature & BitcoinSignTransactionFeature;
+/** Type alias for some or all Bitcoin features. */
+export type BitcoinFeatures =
+    | BitcoinConnectFeature
+    | BitcoinSignTransactionFeature
+    | BitcoinSignAndSendTransactionFeature;
 
 /** Wallet with Bitcoin features. */
 export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
 
 export * from './connect.js';
 export * from './signTransaction.js';
+export * from './signAndSendTransaction.js';

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -1,0 +1,61 @@
+import type { IdentifierString } from '@wallet-standard/base';
+
+import type { BitcoinSignTransactionInput } from './signTransaction.js';
+
+/** Name of the feature. */
+export const BitcoinSignAndSendTransaction = 'bitcoin:signAndSendTransaction';
+
+/**
+ * `bitcoin:signAndSendTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be
+ * implemented by a {@link "@wallet-standard/base".Wallet} to allow the app to request to sign transactions with the
+ * specified {@link "@wallet-standard/base".Wallet.accounts} and send them to the
+ * {@link "@wallet-standard/base".Wallet.chains | chain}.
+ *
+ * @group SignAndSendTransaction
+ */
+export type BitcoinSignAndSendTransactionFeature = {
+    /** Name of the feature. */
+    readonly [BitcoinSignAndSendTransaction]: {
+        /** Version of the feature implemented by the Wallet. */
+        readonly version: BitcoinSignAndSendTransactionVersion;
+
+        /** Method to call to use the feature. */
+        readonly signAndSendTransaction: BitcoinSignAndSendTransactionMethod;
+    };
+};
+
+/**
+ * Version of the {@link BitcoinSignAndSendTransactionFeature} implemented by a {@link "@wallet-standard/base".Wallet}.
+ *
+ * @group SignAndSendTransaction
+ */
+export type BitcoinSignAndSendTransactionVersion = '1.0.0';
+
+/**
+ * Method to call to use the {@link BitcoinSignAndSendTransactionFeature}.
+ *
+ * @group SignAndSendTransaction
+ */
+export type BitcoinSignAndSendTransactionMethod = (
+    ...inputs: readonly BitcoinSignAndSendTransactionInput[]
+) => Promise<readonly BitcoinSignAndSendTransactionOutput[]>;
+
+/**
+ * Input for the {@link BitcoinSignAndSendTransactionMethod}.
+ *
+ * @group SignAndSendTransaction
+ */
+export interface BitcoinSignAndSendTransactionInput extends BitcoinSignTransactionInput {
+    /** Chain to use. */
+    readonly chain: IdentifierString;
+}
+
+/**
+ * Output of the {@link BitcoinSignAndSendTransactionMethod}.
+ *
+ * @group SignAndSendTransaction
+ */
+export interface BitcoinSignAndSendTransactionOutput {
+    /** Transaction ID (transaction hash). */
+    readonly txId: string;
+}


### PR DESCRIPTION
## Summary

This PR adds the `bitcoin:signAndSendTransaction` feature.