### PR TITLE
 feat(core:features): add bitcoin:signMessage feature

### DIFF
--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -2,12 +2,14 @@ import type { WalletWithFeatures } from '@wallet-standard/base';
 import type { BitcoinConnectFeature } from './connect.js';
 import type { BitcoinSignAndSendTransactionFeature } from './signAndSendTransaction.js';
 import type { BitcoinSignTransactionFeature } from './signTransaction.js';
+import type { BitcoinSignMessageFeature } from './signMessage.js';
 
 /** Type alias for some or all Bitcoin features. */
 export type BitcoinFeatures =
     | BitcoinConnectFeature
     | BitcoinSignTransactionFeature
-    | BitcoinSignAndSendTransactionFeature;
+    | BitcoinSignAndSendTransactionFeature
+    | BitcoinSignMessageFeature;
 
 /** Wallet with Bitcoin features. */
 export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
@@ -15,3 +17,4 @@ export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
 export * from './connect.js';
 export * from './signTransaction.js';
 export * from './signAndSendTransaction.js';
+export * from './signMessage.js';

--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -1,12 +1,17 @@
 import type { WalletWithFeatures } from '@wallet-standard/base';
 import type { BitcoinConnectFeature } from './connect.js';
+import type { BitcoinSignAndSendTransactionFeature } from './signAndSendTransaction.js';
 import type { BitcoinSignTransactionFeature } from './signTransaction.js';
 
-/** Type of all Bitcoin features. */
-export type BitcoinFeatures = BitcoinConnectFeature & BitcoinSignTransactionFeature;
+/** Type alias for some or all Bitcoin features. */
+export type BitcoinFeatures =
+    | BitcoinConnectFeature
+    | BitcoinSignTransactionFeature
+    | BitcoinSignAndSendTransactionFeature;
 
 /** Wallet with Bitcoin features. */
 export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
 
 export * from './connect.js';
 export * from './signTransaction.js';
+export * from './signAndSendTransaction.js';

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -1,0 +1,61 @@
+import type { IdentifierString } from '@wallet-standard/base';
+
+import type { BitcoinSignTransactionInput } from './signTransaction.js';
+
+/** Name of the feature. */
+export const BitcoinSignAndSendTransaction = 'bitcoin:signAndSendTransaction';
+
+/**
+ * `bitcoin:signAndSendTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be
+ * implemented by a {@link "@wallet-standard/base".Wallet} to allow the app to request to sign transactions with the
+ * specified {@link "@wallet-standard/base".Wallet.accounts} and send them to the
+ * {@link "@wallet-standard/base".Wallet.chains | chain}.
+ *
+ * @group SignAndSendTransaction
+ */
+export type BitcoinSignAndSendTransactionFeature = {
+    /** Name of the feature. */
+    readonly [BitcoinSignAndSendTransaction]: {
+        /** Version of the feature implemented by the Wallet. */
+        readonly version: BitcoinSignAndSendTransactionVersion;
+
+        /** Method to call to use the feature. */
+        readonly signAndSendTransaction: BitcoinSignAndSendTransactionMethod;
+    };
+};
+
+/**
+ * Version of the {@link BitcoinSignAndSendTransactionFeature} implemented by a {@link "@wallet-standard/base".Wallet}.
+ *
+ * @group SignAndSendTransaction
+ */
+export type BitcoinSignAndSendTransactionVersion = '1.0.0';
+
+/**
+ * Method to call to use the {@link BitcoinSignAndSendTransactionFeature}.
+ *
+ * @group SignAndSendTransaction
+ */
+export type BitcoinSignAndSendTransactionMethod = (
+    ...inputs: readonly BitcoinSignAndSendTransactionInput[]
+) => Promise<readonly BitcoinSignAndSendTransactionOutput[]>;
+
+/**
+ * Input for the {@link BitcoinSignAndSendTransactionMethod}.
+ *
+ * @group SignAndSendTransaction
+ */
+export interface BitcoinSignAndSendTransactionInput extends BitcoinSignTransactionInput {
+    /** Chain to use. */
+    readonly chain: IdentifierString;
+}
+
+/**
+ * Output of the {@link BitcoinSignAndSendTransactionMethod}.
+ *
+ * @group SignAndSendTransaction
+ */
+export interface BitcoinSignAndSendTransactionOutput {
+    /** Transaction ID (transaction hash). */
+    readonly txId: string;
+}

--- a/packages/core/features/src/signMessage.ts
+++ b/packages/core/features/src/signMessage.ts
@@ -1,0 +1,71 @@
+import type { WalletAccount } from '@wallet-standard/base';
+
+/** Name of the feature. */
+export const BitcoinSignMessage = 'bitcoin:signMessage';
+
+/**
+ * `bitcoin:signMessage` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
+ * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a message with the specified
+ * {@link "@wallet-standard/base".Wallet.accounts | account}.
+ *
+ * The wallet should prefix the message to be signed to avoid signing a valid transaction.
+ * For an example of the prefix (and hashing algorithm), see:
+ * https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/index.js#L57.
+ *
+ * @group SignMessage
+ */
+export type BitcoinSignMessageFeature = {
+    /** Name of the feature. */
+    readonly [BitcoinSignMessage]: {
+        /** Version of the feature implemented by the Wallet. */
+        readonly version: BitcoinSignMessageVersion;
+
+        /** Method to call to use the feature. */
+        readonly signMessage: BitcoinSignMessageMethod;
+    };
+};
+
+/**
+ * Version of the {@link BitcoinSignMessageFeature} implemented by a {@link "@wallet-standard/base".Wallet}.
+ *
+ * @group SignMessage
+ */
+export type BitcoinSignMessageVersion = '1.0.0';
+
+/**
+ * Method to call to use the {@link BitcoinSignMessageFeature}.
+ *
+ * @group SignMessage
+ */
+export type BitcoinSignMessageMethod = (
+    ...input: BitcoinSignMessageInput[]
+) => Promise<readonly BitcoinSignMessageOutput[]>;
+
+/**
+ * Input for the {@link BitcoinSignMessageMethod}.
+ *
+ * @group SignMessage
+ */
+export interface BitcoinSignMessageInput {
+    /** Account to use. */
+    readonly account: WalletAccount;
+
+    /** Message to sign, as raw bytes. */
+    readonly message: Uint8Array;
+}
+
+/**
+ * Output of the {@link BitcoinSignMessageMethod}.
+ *
+ * @group SignMessage
+ */
+export interface BitcoinSignMessageOutput {
+    /**
+     * Message bytes that were signed.
+     * The wallet may prefix or otherwise modify the message before signing it.
+     */
+    readonly signedMessage: Uint8Array;
+
+    /** Message signature produced. */
+    readonly signature: Uint8Array;
+}

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,4 +1,4 @@
-import type { IdentifierString, Wallet, WalletAccount } from '@wallet-standard/base';
+import type { IdentifierString, WalletAccount } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const BitcoinSignTransaction = 'bitcoin:signTransaction';

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletAccount } from '@wallet-standard/base';
+import type { IdentifierString, Wallet, WalletAccount } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const BitcoinSignTransaction = 'bitcoin:signTransaction';
@@ -45,15 +45,12 @@ export interface BitcoinSignTransactionInput {
     /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
     /** Chain to use. */
-    readonly chain: ArrayElement<Wallet['chains']>;
+    readonly chain: IdentifierString;
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
     /** Whether the wallet should broadcast the signed transaction. */
     readonly broadcast?: boolean;
 }
-
-/** A helper type to infer an array element type. */
-type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
 /**
  * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -57,11 +57,11 @@ export interface BitcoinSignTransactionInput {
  * */
 export interface InputToSign {
     /** Account to use. */
-    account: WalletAccount;
+    readonly account: WalletAccount;
     /** List of input indexes that should be signed by the address. */
-    signingIndexes: number[];
+    readonly signingIndexes: number[];
     /** A SIGHASH flag. */
-    sigHash?: number;
+    readonly sigHash?: number;
 }
 
 /**

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -44,10 +44,10 @@ export type BitcoinSignTransactionMethod = (
 export interface BitcoinSignTransactionInput {
     /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
-    /** Chain to use. */
-    readonly chain: IdentifierString;
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
+    /** Chain to use. */
+    readonly chain?: IdentifierString;
 }
 
 /**

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -5,7 +5,7 @@ export const BitcoinSignTransaction = 'bitcoin:signTransaction';
 
 /**
  * `bitcoin:signTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
- * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a transaction with the specified
+ * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign transactions with the specified
  * {@link "@wallet-standard/base".Wallet.accounts}.
  *
  * @group SignTransaction
@@ -33,8 +33,8 @@ export type BitcoinSignTransactionVersion = '1.0.0';
  * @group SignTransaction
  */
 export type BitcoinSignTransactionMethod = (
-    input: BitcoinSignTransactionInput
-) => Promise<BitcoinSignTransactionOutput>;
+    ...inputs: readonly BitcoinSignTransactionInput[]
+) => Promise<readonly BitcoinSignTransactionOutput[]>;
 
 /**
  * Input for the {@link BitcoinSignTransactionMethod}.

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -15,6 +15,7 @@ export type BitcoinSignTransactionFeature = {
     readonly [BitcoinSignTransaction]: {
         /** Version of the feature implemented by the Wallet. */
         readonly version: BitcoinSignTransactionVersion;
+
         /** Method to call to use the feature. */
         readonly signTransaction: BitcoinSignTransactionMethod;
     };
@@ -44,8 +45,10 @@ export type BitcoinSignTransactionMethod = (
 export interface BitcoinSignTransactionInput {
     /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
+
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
+
     /** Chain to use. */
     readonly chain?: IdentifierString;
 }
@@ -58,8 +61,10 @@ export interface BitcoinSignTransactionInput {
 export interface InputToSign {
     /** Account to use. */
     readonly account: WalletAccount;
+
     /** List of input indexes that should be signed by the address. */
     readonly signingIndexes: number[];
+
     /** A SIGHASH flag. */
     readonly sigHash?: number;
 }

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -6,7 +6,7 @@ export const BitcoinSignTransaction = 'bitcoin:signTransaction';
 /**
  * `bitcoin:signTransaction` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
  * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a transaction with the specified
- * {@link "@wallet-standard/base".Wallet.accounts | account}.
+ * {@link "@wallet-standard/base".Wallet.accounts}.
  *
  * @group SignTransaction
  */
@@ -42,28 +42,21 @@ export type BitcoinSignTransactionMethod = (
  * @group SignTransaction
  */
 export interface BitcoinSignTransactionInput {
-    /**
-     * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
-     */
+    /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
-    /**
-     * Chain to use.
-     */
+    /** Chain to use. */
     readonly chain: ArrayElement<Wallet['chains']>;
-    /**
-     * Transaction inputs to sign.
-     */
+    /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
-    /**
-     * Whether the wallet should broadcast the signed transaction.
-     */
+    /** Whether the wallet should broadcast the signed transaction. */
     readonly broadcast?: boolean;
 }
 
 /** A helper type to infer an array element type. */
 type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
-/** Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
+/**
+ * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
  *
  * @group SignTransaction
  * */
@@ -82,12 +75,11 @@ export interface InputToSign {
  * @group SignTransaction
  */
 export interface BitcoinSignTransactionOutput {
-    /**
-     * Partially Signed Bitcoin Transaction (PSBT), as raw bytes.
-     */
+    /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly psbt: Uint8Array;
     /**
      * Transaction hash.
+     *
      * Returned if `broadcast: true` was passed in the {@link BitcoinSignTransactionInput}.
      */
     txId?: string;

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -72,8 +72,8 @@ export interface InputToSign {
  * @group SignTransaction
  */
 export interface BitcoinSignTransactionOutput {
-    /** Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
-    readonly psbt: Uint8Array;
+    /** Signed Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
+    readonly signedPsbt: Uint8Array;
     /**
      * Transaction hash.
      *

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -66,7 +66,7 @@ export interface InputToSign {
     readonly signingIndexes: number[];
 
     /** A SIGHASH flag. */
-    readonly sigHash?: number;
+    readonly sigHash?: BitcoinSigHashFlag;
 }
 
 /**
@@ -78,3 +78,12 @@ export interface BitcoinSignTransactionOutput {
     /** Signed Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly signedPsbt: Uint8Array;
 }
+
+/** SIGHASH flag. */
+export type BitcoinSigHashFlag =
+    | 'ALL'
+    | 'NONE'
+    | 'SINGLE'
+    | 'ALL|ANYONECANPAY'
+    | 'NONE|ANYONECANPAY'
+    | 'SINGLE|ANYONECANPAY';

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -48,8 +48,6 @@ export interface BitcoinSignTransactionInput {
     readonly chain: IdentifierString;
     /** Transaction inputs to sign. */
     readonly inputsToSign: InputToSign[];
-    /** Whether the wallet should broadcast the signed transaction. */
-    readonly broadcast?: boolean;
 }
 
 /**
@@ -74,10 +72,4 @@ export interface InputToSign {
 export interface BitcoinSignTransactionOutput {
     /** Signed Partially Signed Bitcoin Transaction (PSBT), as raw bytes. */
     readonly signedPsbt: Uint8Array;
-    /**
-     * Transaction hash.
-     *
-     * Returned if `broadcast: true` was passed in the {@link BitcoinSignTransactionInput}.
-     */
-    txId?: string;
 }

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -53,13 +53,13 @@ export interface BitcoinSignTransactionInput {
 }
 
 /**
- * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount.address}.
+ * Transaction input to be signed with the specified {@link "@wallet-standard/base".WalletAccount | account}.
  *
  * @group SignTransaction
  * */
 export interface InputToSign {
-    /** Address to use. */
-    address: WalletAccount['address'];
+    /** Account to use. */
+    account: WalletAccount;
     /** List of input indexes that should be signed by the address. */
     signingIndexes: number[];
     /** A SIGHASH flag. */


### PR DESCRIPTION
This PR adds a feature for doing message signing as implemented by https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/index.js#L57 and many other libraries in the ecosystem.

This PR does not preclude the introduction of a feature or parameter that introduces bip322 message signing via bitcoin-wallet-standard.