### PR TITLE
 feat(core:features): add bitcoin:signMessage feature 

### DIFF
--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -2,12 +2,14 @@ import type { WalletWithFeatures } from '@wallet-standard/base';
 import type { BitcoinConnectFeature } from './connect.js';
 import type { BitcoinSignAndSendTransactionFeature } from './signAndSendTransaction.js';
 import type { BitcoinSignTransactionFeature } from './signTransaction.js';
+import type { BitcoinSignMessageFeature } from './signMessage.js';
 
 /** Type alias for some or all Bitcoin features. */
 export type BitcoinFeatures =
     | BitcoinConnectFeature
     | BitcoinSignTransactionFeature
-    | BitcoinSignAndSendTransactionFeature;
+    | BitcoinSignAndSendTransactionFeature
+    | BitcoinSignMessageFeature;
 
 /** Wallet with Bitcoin features. */
 export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
@@ -15,3 +17,4 @@ export type WalletWithBitcoinFeatures = WalletWithFeatures<BitcoinFeatures>;
 export * from './connect.js';
 export * from './signTransaction.js';
 export * from './signAndSendTransaction.js';
+export * from './signMessage.js';

--- a/packages/core/features/src/signMessage.ts
+++ b/packages/core/features/src/signMessage.ts
@@ -1,0 +1,71 @@
+import type { WalletAccount } from '@wallet-standard/base';
+
+/** Name of the feature. */
+export const BitcoinSignMessage = 'bitcoin:signMessage';
+
+/**
+ * `bitcoin:signMessage` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
+ * {@link "@wallet-standard/base".Wallet} to allow the app to request to sign a message with the specified
+ * {@link "@wallet-standard/base".Wallet.accounts | account}.
+ *
+ * The wallet should prefix the message to be signed to avoid signing a valid transaction.
+ * For an example of the prefix (and hashing algorithm), see:
+ * https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/index.js#L57.
+ *
+ * @group SignMessage
+ */
+export type BitcoinSignMessageFeature = {
+    /** Name of the feature. */
+    readonly [BitcoinSignMessage]: {
+        /** Version of the feature implemented by the Wallet. */
+        readonly version: BitcoinSignMessageVersion;
+
+        /** Method to call to use the feature. */
+        readonly signMessage: BitcoinSignMessageMethod;
+    };
+};
+
+/**
+ * Version of the {@link BitcoinSignMessageFeature} implemented by a {@link "@wallet-standard/base".Wallet}.
+ *
+ * @group SignMessage
+ */
+export type BitcoinSignMessageVersion = '1.0.0';
+
+/**
+ * Method to call to use the {@link BitcoinSignMessageFeature}.
+ *
+ * @group SignMessage
+ */
+export type BitcoinSignMessageMethod = (
+    ...input: BitcoinSignMessageInput[]
+) => Promise<readonly BitcoinSignMessageOutput[]>;
+
+/**
+ * Input for the {@link BitcoinSignMessageMethod}.
+ *
+ * @group SignMessage
+ */
+export interface BitcoinSignMessageInput {
+    /** Account to use. */
+    readonly account: WalletAccount;
+
+    /** Message to sign, as raw bytes. */
+    readonly message: Uint8Array;
+}
+
+/**
+ * Output of the {@link BitcoinSignMessageMethod}.
+ *
+ * @group SignMessage
+ */
+export interface BitcoinSignMessageOutput {
+    /**
+     * Message bytes that were signed.
+     * The wallet may prefix or otherwise modify the message before signing it.
+     */
+    readonly signedMessage: Uint8Array;
+
+    /** Message signature produced. */
+    readonly signature: Uint8Array;
+}


### PR DESCRIPTION
This PR adds a feature for doing message signing as implemented by https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/index.js#L57 and many other libraries in the ecosystem.

This PR does not preclude the introduction of a feature or parameter that introduces bip322 message signing via bitcoin-wallet-standard.
